### PR TITLE
Passeio cavalo com @lru_cache

### DIFF
--- a/2_paradigmas/06_passeio_cavalo.py
+++ b/2_paradigmas/06_passeio_cavalo.py
@@ -1,4 +1,15 @@
-from pprint import pprint
+'''Uso de lru_cache na função tenta()
+> python3 06_passeio_cavalo.py CACHE_SIZE
+
+O melhor valor de CACHE_SIZE nos testes foi 15'''
+
+
+import sys
+from timeit import timeit
+from functools import lru_cache
+from rich import print
+
+MAX_CACHE = int(sys.argv[1])
 
 
 class PasseioCavalo:
@@ -21,7 +32,12 @@ class PasseioCavalo:
         ]
         self.tabuleiro[inicio[0]][inicio[1]] = 1
 
+        self.count_tenta = 0
+
+    @lru_cache(maxsize=MAX_CACHE)
     def tenta(self, passo_n, pos_x, pos_y):
+
+        self.count_tenta += 1
         for direcao in self.PASSOS:
             ctrl_sucesso = False
 
@@ -61,7 +77,16 @@ class PasseioCavalo:
         self.tabuleiro[x][y] = 0
 
 
+def main(N):
+    p = PasseioCavalo(N)
+    print(f"Começando com N = {N} e max_cache = {MAX_CACHE}")
+    p.tenta(2, 0, 0)
+    if p.tabuleiro:
+        print("> > > count_ITER: " + str(p.count_tenta))
+    p.tenta.cache_clear()
+
+
 if __name__ == "__main__":
-    p = PasseioCavalo(5)
-    if p.tenta(2, 0, 0):
-        pprint(p.tabuleiro)
+
+    for N in range(4, 8):
+        print("> > > time: " + str(timeit(lambda: main(N), number=1)))

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Como o repositório é inspirado no livro *Projeto de Algoritmos*, a estrutura d
 7. Algoritmos em Grafos
 8. Processamento de Cadeias de Caracteres
 9. Problemas NP-Completo e Heuristicas
- 
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Como o repositório é inspirado no livro *Projeto de Algoritmos*, a estrutura d
 7. Algoritmos em Grafos
 8. Processamento de Cadeias de Caracteres
 9. Problemas NP-Completo e Heuristicas
+ 

--- a/README.md
+++ b/README.md
@@ -26,4 +26,3 @@ Como o repositório é inspirado no livro *Projeto de Algoritmos*, a estrutura d
 7. Algoritmos em Grafos
 8. Processamento de Cadeias de Caracteres
 9. Problemas NP-Completo e Heuristicas
-


### PR DESCRIPTION
Essa branch/PR tem finalidade apenas para estudo do decorator `@lru_cache` no Python.

O decorator ajuda a otimizarmos o calculo de uma função que é chamada repetidas vezes durante a execução do programa.

Entretanto obtive resultados interessantes (estranhos, ao meu ver) ao utilizar diferentes valores no parâmetro `maxsize=` do decorator.

Mais estranhamente ainda, utlizar o decorator `@cache` fez com que o programa tivesse um resultado incorreto (acusando que não havia solução para o problema do cavalo com `N=6`). 

Alguns dos resultados estão no print abaixo:

> N = numero de linhas/colunas no tabuleiro
> count_ITER = numero de execuções do método `tenta()`
> time: tempo decorrido, em segundos

![image](https://user-images.githubusercontent.com/10200286/141809885-d0093c30-e941-4ba5-8a83-b3ceeb357d44.png)
